### PR TITLE
Always return from onMessageAsync method--even if an exception is thrown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group "com.r3"
-version "1.0.0"
+version "1.0.1"
 
 buildscript {
     ext {

--- a/src/main/kotlin/com/r3/logicapps/BusMessageHandler.kt
+++ b/src/main/kotlin/com/r3/logicapps/BusMessageHandler.kt
@@ -32,9 +32,9 @@ class BusMessageHandler(
             handleRequest(workbenchAdapter.transformIngress(payload), message.lockToken)
         } catch (exception: IngressFormatException) {
             handleError(exception, message.lockToken)
+        } finally {
+            return CompletableFuture.completedFuture(null)
         }
-
-        return CompletableFuture.completedFuture(null)
     }
 
     private fun handleRequest(request: BusRequest, messageLockTokenId: UUID) {


### PR DESCRIPTION
On the shared demo system we observed a situation in which messages would no longer be consumed from the bus.
Occurrences of this error seemed to coincide with exception bubbling up to the `logicapps.BusMessageHandler.onMessageAsync` handler.
Should this method always return?

```
[INFO ] 2019-06-20T08:04:57,601Z [pool-10-thread-1] logicapps.BusMessageHandler.handleRequest - Sending reply: {
	"messageName" : "ContractMessage",
	"requestId" : "94278f5e-447f-4290-83dd-280a3d8aef5a",
	"additionalInformation" : {
		"ledgerType" : "corda",
		"platformVersion" : 4
	},
	"contractLedgerIdentifier" : "a41b7e8f-f02a-48aa-95d8-67e6e979c044",
	"contractProperties" : [
		{
			"workflowPropertyId" : null,
			"name" : "state",
			"value" : "InTransit"
		},
		{
			"workflowPropertyId" : null,
			"name" : "owner",
			"value" : "O=Alice, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "initiatingCounterparty",
			"value" : "O=Alice, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "counterparty",
			"value" : "O=Bob, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "previousCounterparty",
			"value" : "O=Alice, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "device",
			"value" : "OU=Device 01, O=Alice, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "supplyChainOwner",
			"value" : "O=Bob, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "supplyChainObserver",
			"value" : "O=Charlie, L=London, C=GB"
		},
		{
			"workflowPropertyId" : null,
			"name" : "minHumidity",
			"value" : "0"
		},
		{
			"workflowPropertyId" : null,
			"name" : "maxHumidity",
			"value" : "60"
		},
		{
			"workflowPropertyId" : null,
			"name" : "minTemperature",
			"value" : "0"
		},
		{
			"workflowPropertyId" : null,
			"name" : "maxTemperature",
			"value" : "10"
		},
		{
			"workflowPropertyId" : null,
			"name" : "complianceSensorType",
			"value" : "null"
		},
		{
			"workflowPropertyId" : null,
			"name" : "complianceSensorReading",
			"value" : "null"
		},
		{
			"workflowPropertyId" : null,
			"name" : "complianceStatus",
			"value" : "true"
		},
		{
			"workflowPropertyId" : null,
			"name" : "complianceDetail",
			"value" : "null"
		},
		{
			"workflowPropertyId" : null,
			"name" : "lastSensorUpdateTimestamp",
			"value" : "null"
		}
	],
	"messageSchemaVersion" : "1.0.0"
}
[INFO ] 2019-06-20T08:04:57,602Z [pool-10-thread-1] servicebus.ServicebusClientImpl.send - Sending message to from-corda
[INFO ] 2019-06-20T08:04:57,622Z [pool-10-thread-1] servicebus.ServicebusClientImpl.send - Message sent
[INFO ] 2019-06-20T08:04:57,625Z [pool-10-thread-1] logicapps.BusMessageHandler.onMessageAsync - Received message: {"contractLedgerIdentifier":"a41b7e8f-f02a-48aa-95d8-67e6e979c044","workflowFunctionName":"TransferResponsibility","parameters":[{"name":"newCounterparty","value":"O=Bob, L=London, C=GB"}],"requestId":"120c8338-1e67-4e9d-8ab0-00bf253f8382","messageSchemaVersion":"1.0.0","messageName":"CreateContractActionRequest"}
[WARN ] 2019-06-20T08:04:57,657Z [Node thread-1] contracts.TransactionState.<init> - State class net.corda.logicapps.refrigeratedTransportation.Shipment is not annotated with @BelongsToContract, and does not have an enclosing class which implements Contract. Annotate Shipment with @BelongsToContract(net.corda.logicapps.refrigeratedTransportation.RefrigerationContract.class) to remove this warning. {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[INFO ] 2019-06-20T08:04:57,658Z [Node thread-1] corda.flow.run - Flow raised an error... sending it to flow hospital {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:58) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:28) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:228) ~[corda-node-4.0.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:45) ~[corda-node-4.0.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_202]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at net.corda.node.utilities.AffinityExecutor$ServiceAffinityExecutor$1$thread$1.run(AffinityExecutor.kt:63) ~[corda-node-4.0.jar:?]
[INFO ] 2019-06-20T08:04:57,660Z [Node thread-1] statemachine.StaffedFlowHospital.flowErrored - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] admitted to hospital in state StateMachineState(checkpoint=Checkpoint(invocationContext=InvocationContext(origin=Service(serviceClassName=com.r3.logicapps.LogicAppService, owningLegalIdentity=O=Alice, L=London, C=GB), trace=Trace(invocationId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Invocation, sessionId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Session), actor=null, externalTrace=null, impersonatedActor=null), ourIdentity=O=Alice, L=London, C=GB, sessions={}, subFlowStack=[Initiating(flowClass=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, classToInitiateWith=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, flowInfo=FlowInfo(flowVersion=1, appName=refrigerated-transportation-2.0.0-SNAPSHOT), subFlowVersion=CorDappFlow(platformVersion=4, corDappName=refrigerated-transportation-2.0.0-SNAPSHOT, corDappHash=F1FBF6F4B8223D1E79D5BC90050CCAFA1FC2139177CFCEFD31FAC12E29FCCAFD), isEnabledTimedFlow=false)], flowState=Unstarted(flowStart=Explicit, frozenFlowLogic=79E1383445931494D9B029AA7DBD0380F2841C7FC8A27BC0670AB7DB112E9C24), errorState=Clean, numberOfSuspends=0), flowLogic=net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility@12ca9a1c, pendingDeduplicationHandlers=[], isFlowResumed=true, isTransactionTracked=false, isAnyCheckpointPersisted=true, isStartIdempotent=false, isRemoved=false, senderUUID=5a10478e-1af3-4497-b74a-462b04a8f9c4) {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[INFO ] 2019-06-20T08:04:57,661Z [Node thread-1] statemachine.StaffedFlowHospital.invoke - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] has error [0] {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:58) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:28) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:228) ~[corda-node-4.0.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:45) ~[corda-node-4.0.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_202]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at net.corda.node.utilities.AffinityExecutor$ServiceAffinityExecutor$1$thread$1.run(AffinityExecutor.kt:63) ~[corda-node-4.0.jar:?]
[INFO ] 2019-06-20T08:04:57,662Z [Node thread-1] statemachine.StaffedFlowHospital.flowErrored - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] error allowed to propagate {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[WARN ] 2019-06-20T08:04:57,668Z [Node thread-1] interceptors.DumpHistoryOnErrorInterceptor.executeTransition - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] errored, dumping all transitions:

 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.649Z
  Event: DoRemainingWork
  Actions:
    CreateTransaction
    PersistCheckpoint(id=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371], checkpoint=Checkpoint(invocationContext=InvocationContext(origin=Service(serviceClassName=com.r3.logicapps.LogicAppService, owningLegalIdentity=O=Alice, L=London, C=GB), trace=Trace(invocationId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Invocation, sessionId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Session), actor=null, externalTrace=null, impersonatedActor=null), ourIdentity=O=Alice, L=London, C=GB, sessions={}, subFlowStack=[Initiating(flowClass=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, classToInitiateWith=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, flowInfo=FlowInfo(flowVersion=1, appName=refrigerated-transportation-2.0.0-SNAPSHOT), subFlowVersion=CorDappFlow(platformVersion=4, corDappName=refrigerated-transportation-2.0.0-SNAPSHOT, corDappHash=F1FBF6F4B8223D1E79D5BC90050CCAFA1FC2139177CFCEFD31FAC12E29FCCAFD), isEnabledTimedFlow=false)], flowState=Unstarted(flowStart=Explicit, frozenFlowLogic=79E1383445931494D9B029AA7DBD0380F2841C7FC8A27BC0670AB7DB112E9C24), errorState=Clean, numberOfSuspends=0), isCheckpointUpdate=false)
    PersistDeduplicationFacts(deduplicationHandlers=[net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0])
    CommitTransaction
    AcknowledgeMessages(deduplicationHandlers=[net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0])
    SignalFlowHasStarted(flowId=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371])
    CreateTransaction
  Continuation: Resume(result=null)
  Diff between previous and next state:
isFlowResumed:
    false
    true
pendingDeduplicationHandlers:
    [net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0]
    []
isAnyCheckpointPersisted:
    false
    true


 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.662Z
  Event: Error(exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)
  Actions:
    RollbackTransaction
    ScheduleEvent(event=DoRemainingWork)
  Continuation: ProcessEvents
  Diff between previous and next state:
isFlowResumed:
    true
    false
checkpoint.errorState:
    Clean
    Errored(errors=[FlowError(errorId=1497063023590883074, exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)], propagatedIndex=0, propagating=false)


 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.663Z
  Event: DoRemainingWork
  Actions:

  Continuation: ProcessEvents
  Diff between previous and next state:
null

 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.663Z
  Event: StartErrorPropagation
  Actions:
    ScheduleEvent(event=DoRemainingWork)
  Continuation: ProcessEvents
  Diff between previous and next state:
checkpoint.errorState.propagating:
    false
    true
 {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[WARN ] 2019-06-20T08:04:57,669Z [Node thread-1] interceptors.DumpHistoryOnErrorInterceptor.executeTransition - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] error [errorCode=1l94uyo, moreInformationAt=https://errors.corda.net/OS/4.0/1l94uyo] {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:58) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:28) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:228) ~[corda-node-4.0.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:45) ~[corda-node-4.0.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_202]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at net.corda.node.utilities.AffinityExecutor$ServiceAffinityExecutor$1$thread$1.run(AffinityExecutor.kt:63) ~[corda-node-4.0.jar:?]
[WARN ] 2019-06-20T08:04:57,670Z [Node thread-1] statemachine.ActionExecutorImpl.executePropagateErrors - Propagating error {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[WARN ] 2019-06-20T08:04:57,681Z [Node thread-1] interceptors.DumpHistoryOnErrorInterceptor.executeTransition - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] errored, dumping all transitions:

 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.649Z
  Event: DoRemainingWork
  Actions:
    CreateTransaction
    PersistCheckpoint(id=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371], checkpoint=Checkpoint(invocationContext=InvocationContext(origin=Service(serviceClassName=com.r3.logicapps.LogicAppService, owningLegalIdentity=O=Alice, L=London, C=GB), trace=Trace(invocationId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Invocation, sessionId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Session), actor=null, externalTrace=null, impersonatedActor=null), ourIdentity=O=Alice, L=London, C=GB, sessions={}, subFlowStack=[Initiating(flowClass=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, classToInitiateWith=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, flowInfo=FlowInfo(flowVersion=1, appName=refrigerated-transportation-2.0.0-SNAPSHOT), subFlowVersion=CorDappFlow(platformVersion=4, corDappName=refrigerated-transportation-2.0.0-SNAPSHOT, corDappHash=F1FBF6F4B8223D1E79D5BC90050CCAFA1FC2139177CFCEFD31FAC12E29FCCAFD), isEnabledTimedFlow=false)], flowState=Unstarted(flowStart=Explicit, frozenFlowLogic=79E1383445931494D9B029AA7DBD0380F2841C7FC8A27BC0670AB7DB112E9C24), errorState=Clean, numberOfSuspends=0), isCheckpointUpdate=false)
    PersistDeduplicationFacts(deduplicationHandlers=[net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0])
    CommitTransaction
    AcknowledgeMessages(deduplicationHandlers=[net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0])
    SignalFlowHasStarted(flowId=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371])
    CreateTransaction
  Continuation: Resume(result=null)
  Diff between previous and next state:
isFlowResumed:
    false
    true
pendingDeduplicationHandlers:
    [net.corda.node.internal.FlowStarterImpl$startFlow$startFlowEvent$1@1c90e8f0]
    []
isAnyCheckpointPersisted:
    false
    true


 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.662Z
  Event: Error(exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)
  Actions:
    RollbackTransaction
    ScheduleEvent(event=DoRemainingWork)
  Continuation: ProcessEvents
  Diff between previous and next state:
isFlowResumed:
    true
    false
checkpoint.errorState:
    Clean
    Errored(errors=[FlowError(errorId=1497063023590883074, exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)], propagatedIndex=0, propagating=false)


 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.663Z
  Event: DoRemainingWork
  Actions:

  Continuation: ProcessEvents
  Diff between previous and next state:
null

 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.663Z
  Event: StartErrorPropagation
  Actions:
    ScheduleEvent(event=DoRemainingWork)
  Continuation: ProcessEvents
  Diff between previous and next state:
checkpoint.errorState.propagating:
    false
    true


 --- Transition of flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] ---
  Timestamp: 2019-06-20T08:04:57.673Z
  Event: DoRemainingWork
  Actions:
    PropagateErrors(errorMessages=[ErrorSessionMessage(flowException=null, errorId=1497063023590883074)], sessions=[], senderUUID=5a10478e-1af3-4497-b74a-462b04a8f9c4)
    CreateTransaction
    RemoveCheckpoint(id=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371])
    PersistDeduplicationFacts(deduplicationHandlers=[])
    ReleaseSoftLocks(uuid=d0320a0c-9d64-49e9-8bb2-1cd20b96d371)
    CommitTransaction
    AcknowledgeMessages(deduplicationHandlers=[])
    RemoveSessionBindings(sessionIds=[])
    RemoveFlow(flowId=[d0320a0c-9d64-49e9-8bb2-1cd20b96d371], removalReason=ErrorFinish(flowErrors=[FlowError(errorId=1497063023590883074, exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)]), lastState=StateMachineState(checkpoint=Checkpoint(invocationContext=InvocationContext(origin=Service(serviceClassName=com.r3.logicapps.LogicAppService, owningLegalIdentity=O=Alice, L=London, C=GB), trace=Trace(invocationId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Invocation, sessionId=86ef36c8-0698-4942-a4dc-17858ee0bfd5, timestamp: 2019-06-20T08:04:57.642Z, entityType: Session), actor=null, externalTrace=null, impersonatedActor=null), ourIdentity=O=Alice, L=London, C=GB, sessions={}, subFlowStack=[Initiating(flowClass=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, classToInitiateWith=class net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility, flowInfo=FlowInfo(flowVersion=1, appName=refrigerated-transportation-2.0.0-SNAPSHOT), subFlowVersion=CorDappFlow(platformVersion=4, corDappName=refrigerated-transportation-2.0.0-SNAPSHOT, corDappHash=F1FBF6F4B8223D1E79D5BC90050CCAFA1FC2139177CFCEFD31FAC12E29FCCAFD), isEnabledTimedFlow=false)], flowState=Unstarted(flowStart=Explicit, frozenFlowLogic=79E1383445931494D9B029AA7DBD0380F2841C7FC8A27BC0670AB7DB112E9C24), errorState=Errored(errors=[FlowError(errorId=1497063023590883074, exception=java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty)], propagatedIndex=1, propagating=true), numberOfSuspends=0), flowLogic=net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility@12ca9a1c, pendingDeduplicationHandlers=[], isFlowResumed=false, isTransactionTracked=false, isAnyCheckpointPersisted=true, isStartIdempotent=false, isRemoved=true, senderUUID=5a10478e-1af3-4497-b74a-462b04a8f9c4))
  Continuation: Abort
  Diff between previous and next state:
checkpoint.errorState.propagatedIndex:
    0
    1
isRemoved:
    false
    true
 {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
[WARN ] 2019-06-20T08:04:57,682Z [Node thread-1] interceptors.DumpHistoryOnErrorInterceptor.executeTransition - Flow [d0320a0c-9d64-49e9-8bb2-1cd20b96d371] error [errorCode=1l94uyo, moreInformationAt=https://errors.corda.net/OS/4.0/1l94uyo] {fiber-id=10004974, flow-id=d0320a0c-9d64-49e9-8bb2-1cd20b96d371, invocation_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, invocation_timestamp=2019-06-20T08:04:57.642Z, origin=com.r3.logicapps.LogicAppService, session_id=86ef36c8-0698-4942-a4dc-17858ee0bfd5, session_timestamp=2019-06-20T08:04:57.642Z, thread-id=131}
java.lang.IllegalArgumentException: Transfer cannot be to the same counterparty
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:58) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.logicapps.refrigeratedTransportation.flow.TransferResponsibility.call(TransferResponsibility.kt:28) ~[refrigerated-transportation-2.0.0-SNAPSHOT.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:228) ~[corda-node-4.0.jar:?]
	at net.corda.node.services.statemachine.FlowStateMachineImpl.run(FlowStateMachineImpl.kt:45) ~[corda-node-4.0.jar:?]
	at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1092) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:788) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91) ~[quasar-core-0.7.10-jdk8.jar:0.7.10]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_202]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_202]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at net.corda.node.utilities.AffinityExecutor$ServiceAffinityExecutor$1$thread$1.run(AffinityExecutor.kt:63) ~[corda-node-4.0.jar:?]
[INFO ] 2019-06-20T08:05:17,614Z [pool-11-thread-32] primitives.RequestResponseLink.recreateInternalLinks - RequestResponseLink - recreating internal send and receive links to to-corda/$management
[INFO ] 2019-06-20T08:05:17,622Z [pool-11-thread-33] primitives.RequestResponseLink.lambda$recreateInternalLinks$5 - Recreated internal links to to-corda/$management
[ERROR] 2019-06-20T08:05:17,791Z [pool-11-thread-32] primitives.CoreMessageReceiver.lambda$null$12 - Renewing message locks for lock tokens '[a7168b95-109f-46ea-b77b-7ac8ec244893]' on entity 'to-corda' failed [errorCode=1urbx2v, moreInformationAt=https://errors.corda.net/OS/4.0/1urbx2v]
com.microsoft.azure.servicebus.primitives.MessageLockLostException: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. Reference:c3ea28e3-50e9-49d6-95eb-bb8e2a352233, TrackingId:86ce4acb-6873-4b67-8390-e3441f7029fc_B40, SystemTracker:corda-demo-alice:Queue:to-corda, Timestamp:2019-06-20T08:05:17
	at com.microsoft.azure.servicebus.primitives.ExceptionUtil.toException(ExceptionUtil.java:94) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseUtils.generateExceptionFromError(RequestResponseUtils.java:97) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseUtils.genereateExceptionFromResponse(RequestResponseUtils.java:92) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.CoreMessageReceiver.lambda$null$12(CoreMessageReceiver.java:1310) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:952) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:926) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
[ERROR] 2019-06-20T08:05:17,792Z [pool-11-thread-34] servicebus.MessageAndSessionPump.lambda$null$0 - Renewing lock on 'message with locktoken : a7168b95-109f-46ea-b77b-7ac8ec244893, sequence number : 24643' failed [errorCode=1urbx2v, moreInformationAt=https://errors.corda.net/OS/4.0/1urbx2v]
com.microsoft.azure.servicebus.primitives.MessageLockLostException: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. Reference:c3ea28e3-50e9-49d6-95eb-bb8e2a352233, TrackingId:86ce4acb-6873-4b67-8390-e3441f7029fc_B40, SystemTracker:corda-demo-alice:Queue:to-corda, Timestamp:2019-06-20T08:05:17
	at com.microsoft.azure.servicebus.primitives.ExceptionUtil.toException(ExceptionUtil.java:94) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseUtils.generateExceptionFromError(RequestResponseUtils.java:97) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseUtils.genereateExceptionFromResponse(RequestResponseUtils.java:92) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.CoreMessageReceiver.lambda$null$12(CoreMessageReceiver.java:1310) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:952) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:926) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_202]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_202]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
[WARN ] 2019-06-20T08:14:57,706Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.CoreMessageSender.onError - Send link '95e184_c28311f216f7433093cb29ff23d0d09a_G16' to 'from-corda' closed. Failing all pending send requests.
[WARN ] 2019-06-20T08:15:17,735Z [ReactorThreade7a72448-b7dc-4dfe-8d92-ccc860c2af6b] primitives.CoreMessageReceiver.onError - Receive link 'Receiver_719d87_908b19d9bf6a44929c19795a4e4ef83a_G24' to 'to-corda', sessionId 'null' closed with error. [errorCode=j95k8x, moreInformationAt=https://errors.corda.net/OS/4.0/j95k8x]
com.microsoft.azure.servicebus.primitives.ServiceBusException: com.microsoft.azure.servicebus.amqp.AmqpException: The link 'G24:54908:Receiver_719d87_908b19d9bf6a44929c19795a4e4ef83a_G24' is force detached by the broker due to errors occurred in consumer(link123778). Detach origin: AmqpMessageConsumer.IdleTimerExpired: Idle timeout: 00:10:00. TrackingId:03e18cd30000d64b0001e3825d0b2af3_G24_B40, SystemTracker:corda-demo-alice:Queue:to-corda, Timestamp:2019-06-20T08:15:17
	at com.microsoft.azure.servicebus.primitives.ExceptionUtil.toException(ExceptionUtil.java:86) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.CoreMessageReceiver.onError(CoreMessageReceiver.java:798) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.CoreMessageReceiver.onClose(CoreMessageReceiver.java:973) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.processOnClose(BaseLinkHandler.java:68) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.onLinkRemoteClose(BaseLinkHandler.java:42) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at org.apache.qpid.proton.engine.BaseHandler.handle(BaseHandler.java:176) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.engine.impl.EventImpl.dispatch(EventImpl.java:108) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.dispatch(ReactorImpl.java:324) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.process(ReactorImpl.java:291) ~[proton-j-0.27.1.jar:?]
	at com.microsoft.azure.servicebus.primitives.MessagingFactory$RunReactor.run(MessagingFactory.java:484) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
Caused by: com.microsoft.azure.servicebus.amqp.AmqpException: The link 'G24:54908:Receiver_719d87_908b19d9bf6a44929c19795a4e4ef83a_G24' is force detached by the broker due to errors occurred in consumer(link123778). Detach origin: AmqpMessageConsumer.IdleTimerExpired: Idle timeout: 00:10:00. TrackingId:03e18cd30000d64b0001e3825d0b2af3_G24_B40, SystemTracker:corda-demo-alice:Queue:to-corda, Timestamp:2019-06-20T08:15:17
	... 11 more
[INFO ] 2019-06-20T08:15:17,735Z [ReactorThreade7a72448-b7dc-4dfe-8d92-ccc860c2af6b] primitives.CoreMessageReceiver.clearAllPendingWorkItems - Completeing all pending receive and updateState operation on the receiver to 'to-corda'
[WARN ] 2019-06-20T08:19:57,706Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.RequestResponseLink.onClose - Internal send link 'RequestResponseLink-Sender_dd0284' of requestresponselink to '$cbs' closed with error. [errorCode=u7gtd7, moreInformationAt=https://errors.corda.net/OS/4.0/u7gtd7]
com.microsoft.azure.servicebus.primitives.ServiceBusException: Error{condition=amqp:connection:forced, description='The connection was inactive for more than the allowed 300000 milliseconds and is closed by container 'LinkTracker'. TrackingId:c28311f216f7433093cb29ff23d0d09a_G16, SystemTracker:gateway7, Timestamp:2019-06-20T08:19:57', info=null}
	at com.microsoft.azure.servicebus.primitives.ExceptionUtil.toException(ExceptionUtil.java:113) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseLink$InternalSender.onClose(RequestResponseLink.java:846) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.processOnClose(BaseLinkHandler.java:68) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.onLinkRemoteClose(BaseLinkHandler.java:42) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at org.apache.qpid.proton.engine.BaseHandler.handle(BaseHandler.java:176) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.engine.impl.EventImpl.dispatch(EventImpl.java:108) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.dispatch(ReactorImpl.java:324) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.process(ReactorImpl.java:291) ~[proton-j-0.27.1.jar:?]
	at com.microsoft.azure.servicebus.primitives.MessagingFactory$RunReactor.run(MessagingFactory.java:484) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
[WARN ] 2019-06-20T08:19:57,706Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.RequestResponseLink.completeAllPendingRequestsWithException - Completing all pending requests with exception in request response link to $cbs
[WARN ] 2019-06-20T08:19:57,709Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.RequestResponseLink.onClose - Internal receive link 'RequestResponseLink-Receiver_cb36a2' of requestresponselink to '$cbs' closed with error. [errorCode=rroup1, moreInformationAt=https://errors.corda.net/OS/4.0/rroup1]
com.microsoft.azure.servicebus.primitives.ServiceBusException: Error{condition=amqp:connection:forced, description='The connection was inactive for more than the allowed 300000 milliseconds and is closed by container 'LinkTracker'. TrackingId:c28311f216f7433093cb29ff23d0d09a_G16, SystemTracker:gateway7, Timestamp:2019-06-20T08:19:57', info=null}
	at com.microsoft.azure.servicebus.primitives.ExceptionUtil.toException(ExceptionUtil.java:113) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.primitives.RequestResponseLink$InternalReceiver.onClose(RequestResponseLink.java:637) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.processOnClose(BaseLinkHandler.java:68) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at com.microsoft.azure.servicebus.amqp.BaseLinkHandler.onLinkRemoteClose(BaseLinkHandler.java:42) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at org.apache.qpid.proton.engine.BaseHandler.handle(BaseHandler.java:176) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.engine.impl.EventImpl.dispatch(EventImpl.java:108) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.dispatch(ReactorImpl.java:324) ~[proton-j-0.27.1.jar:?]
	at org.apache.qpid.proton.reactor.impl.ReactorImpl.process(ReactorImpl.java:291) ~[proton-j-0.27.1.jar:?]
	at com.microsoft.azure.servicebus.primitives.MessagingFactory$RunReactor.run(MessagingFactory.java:484) ~[corda-logic-app-connector-1.0.0.jar:1.0.0]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
[WARN ] 2019-06-20T08:19:57,709Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.RequestResponseLink.completeAllPendingRequestsWithException - Completing all pending requests with exception in request response link to $cbs
[ERROR] 2019-06-20T08:19:57,709Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.MessagingFactory.onConnectionError - Connection error. 'Error{condition=amqp:connection:forced, description='The connection was inactive for more than the allowed 300000 milliseconds and is closed by container 'LinkTracker'. TrackingId:c28311f216f7433093cb29ff23d0d09a_G16, SystemTracker:gateway7, Timestamp:2019-06-20T08:19:57', info=null}'
[INFO ] 2019-06-20T08:19:57,709Z [ReactorThread4b660653-d2e1-4eee-a7db-35f21555a754] primitives.MessagingFactory.closeConnection - Closing connection to host
```