### PR TITLE
avoid double message ACK in case of flow invocation failure

### DIFF
--- a/src/main/kotlin/com/r3/logicapps/BusMessageHandler.kt
+++ b/src/main/kotlin/com/r3/logicapps/BusMessageHandler.kt
@@ -57,7 +57,7 @@ class BusMessageHandler(
             is CorrelatableIngressFormatException -> CorrelatableError(exception, exception.requestId)
             else                                  -> GenericError(exception)
         }
-        log.info("Acknowledging message with lockTokenId $messageLockTokenId")
+        log.debug("Acknowledging message with lockTokenId $messageLockTokenId")
         busClient.acknowledge(messageLockTokenId)
         busClient.send(workbenchAdapter.transformEgress(error))
     }

--- a/src/main/kotlin/com/r3/logicapps/processing/MessageProcessorImpl.kt
+++ b/src/main/kotlin/com/r3/logicapps/processing/MessageProcessorImpl.kt
@@ -75,7 +75,7 @@ open class MessageProcessorImpl(
             log.debug("Exception during flow logic creation", exception)
             log.debug("Acknowledging message with lockTokenId $messageLockTokenId")
             client.acknowledge(messageLockTokenId)
-            listOf(FlowError(ingressType, requestId, exception, linearId))
+            return listOf(FlowError(ingressType, requestId, exception, linearId))
         }
 
         return try {

--- a/src/main/kotlin/com/r3/logicapps/processing/ServiceDrivenMessageProcessor.kt
+++ b/src/main/kotlin/com/r3/logicapps/processing/ServiceDrivenMessageProcessor.kt
@@ -21,7 +21,7 @@ class ServiceDrivenMessageProcessor(appServiceHub: AppServiceHub) : MessageProce
     startFlowDelegate = { flowLogic, serviceBusClient, messageLockTokenId ->
         val handle = appServiceHub.startFlow(flowLogic)
         // At this point a flow handle exists which means the flow has been checkpointed. It's safe to ACK the message
-        log.info("Acknowledging message with lockTokenId $messageLockTokenId")
+        log.debug("Acknowledging message with lockTokenId $messageLockTokenId")
         serviceBusClient.acknowledge(messageLockTokenId)
 
         // TODO moritzplatt 2019-04-11 -- allow for configuring a timeout


### PR DESCRIPTION
Currently, the bus message is ACKd right after a flow handle is returned. However, if the flow fails, an exception is thrown causing an additional ACK call which breaks the client. The ServiceBus SDK doesn't offer any way (as far as I can tell) of avoiding this (check locks, message status, message is still in queue, etc) and the exception is not propagated outside the library. To workaround this, the sources of potential errors have been dealt with separately:
- deriveFlowLogic can throw and in that case the message should be ACK
- startFlowDelegate can throw only after the flow handle is returned so there should be no ACK done at that point